### PR TITLE
Added (limited) support for serial binary protocol with CRC; sorted-out branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 __pycache__
+python-live-plotting-from-data-stream.sublime-workspace
 plotting.sublime-workspace
 
-quaternion
 
 # c++ socket server files to ignore
 c++_socket_server/server

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "quaternion"]
+	path = quaternion
+	url = git@github.com:erikbrntsn/quaternion.git

--- a/draw_quad.py
+++ b/draw_quad.py
@@ -1,0 +1,50 @@
+import sys
+from visualizeQuad import QuadPlotter
+
+
+def load_src(name, fpath):
+    import os
+    import imp
+    return imp.load_source(name, os.path.join(os.path.dirname(__file__), fpath))
+
+
+mt = load_src('mathTools', 'quaternion/quaternion.py')
+
+
+if len(sys.argv) >= 3:
+  if sys.argv[1] == 'serial':
+    from serial_reader import Reader
+    reader = Reader(port='/dev/ttyUSB0', baudrate=57600)
+
+  elif sys.argv[1] == 'socket':
+    from socket_reader import Reader
+    reader = Reader('10.0.102.2', port=50007)
+
+  elif sys.argv[1] == 'pipe':
+    from pipe_reader import Reader
+    reader = Reader()
+
+  quaLabel = sys.argv[2]
+  if len(sys.argv) == 4:
+    posLabel = sys.argv[3]
+  else:
+    posLabel = None
+
+else:
+  print("Usage <reader (socket/serial/pipe)> <quaLabel> [posLabel]")
+  sys.exit()
+
+plotter = QuadPlotter(reader=reader, quaLabel=quaLabel, posLabel=posLabel, axis=True)
+
+while True:
+  plotter.update()
+
+# lastPlotUpdate = 0
+# while True:
+#   s, data, succes = reader()
+#   if succes and s == label:
+#     q = mt.Quaternion(*data[:4])
+#     pos = data[4:7]
+#     if time.time() - lastPlotUpdate > 0.03:
+#       plotter.drawQuad(q, pos)
+#       lastPlotUpdate = time.time()

--- a/path_following.py
+++ b/path_following.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import time
+import numpy as np
+from matplotlib import pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+from ring import Ring
+
+
+def load_src(name, fpath):
+  import os
+  import imp
+  return imp.load_source(name, os.path.join(os.path.dirname(__file__), fpath))
+
+
+mt = load_src('mathTools', 'quaternion/quaternion.py')
+
+
+def drawQuad(q, lines, pos):
+  lineX = q.rotateVectors(np.array([[0.3,   0,   0], [-0.3,    0, 0]]).T)
+  lineY = q.rotateVectors(np.array([[  0, 0.3,   0], [   0, -0.3, 0]]).T)
+  lineZ = q.rotateVectors(np.array([[  0,   0, 0.3], [   0,    0, 0]]).T)
+
+  lines[0].set_xdata(lineX[0, :] + pos[0])
+  lines[0].set_ydata(lineX[1, :] + pos[1])
+  lines[0].set_3d_properties(lineX[2, :] + pos[2])
+  lines[1].set_xdata(lineY[0, :] + pos[0])
+  lines[1].set_ydata(lineY[1, :] + pos[1])
+  lines[1].set_3d_properties(lineY[2, :] + pos[2])
+  lines[2].set_xdata(lineZ[0, :] + pos[0])
+  lines[2].set_ydata(lineZ[1, :] + pos[1])
+  lines[2].set_3d_properties(lineZ[2, :] + pos[2])
+
+
+class PathPlot(object):
+  def __init__(self, reader, qLabel="q", pCLabel="pC", pDLabel="pD"):
+    # Quaternion, pathCurrent, pathDesired
+    self.qLabel = qLabel
+    self.pCLabel = pCLabel
+    self.pDLabel = pDLabel
+    self.reader = reader
+    self.fig = plt.figure()
+    self.fig.canvas.mpl_connect('key_press_event', self.press)
+    self.ax = self.fig.add_subplot(1, 1, 1, projection='3d', aspect='equal')
+    self.ax.set_xlim3d(-2, 2)
+    self.ax.set_ylim3d(-2, 2)
+    self.ax.set_zlim3d(-2, 2)
+    self.ax.set_xlabel('x')
+    self.ax.set_ylabel('y')
+    self.ax.set_zlabel('z')
+
+    self.pathLines = {}
+    # Actual position
+    self.pathLines[self.pCLabel] = (self.ax.plot([], [], [], 'b.')[0])
+    # Desired position
+    self.pathLines[self.pDLabel] = (self.ax.plot([], [], [], 'r.')[0])
+
+    # Quad
+    self.quadLines = []
+    self.quadLines.append(self.ax.plot([], [], [], 'r', linewidth=2)[0])
+    self.quadLines.append(self.ax.plot([], [], [], 'g', linewidth=2)[0])
+    self.quadLines.append(self.ax.plot([], [], [], 'b', linewidth=2)[0])
+
+    self.lastPlotUpdate = time.time()
+    self.rings = {}
+    self.rings[self.pCLabel] = Ring(3, 1000)
+    self.rings[self.pDLabel] = Ring(3, 1000)
+    self.rings[self.qLabel] = Ring(4, 1000)
+
+
+  def update(self):
+    self.getData()
+    if time.time() - self.lastPlotUpdate > 0.03:
+      self.updatePlotData()
+      self.lastPlotUpdate = time.time()
+
+
+  def updatePlotData(self):
+    # Set data for each line
+    self.pathLines[self.pCLabel].set_data(self.rings[self.pCLabel].yData[0, :], self.rings[self.pCLabel].yData[1, :])
+    self.pathLines[self.pCLabel].set_3d_properties(self.rings[self.pCLabel].yData[2, :])
+
+    self.pathLines[self.pDLabel].set_data(self.rings[self.pDLabel].yData[0, :], self.rings[self.pDLabel].yData[1, :])
+    self.pathLines[self.pDLabel].set_3d_properties(self.rings[self.pDLabel].yData[2, :])
+
+    newestQua = mt.Quaternion(*self.rings[self.qLabel].newest())
+    newestPos = self.rings[self.pCLabel].newest()
+    drawQuad(newestQua, self.quadLines, newestPos)
+
+    plt.pause(0.001)
+
+
+  def getData(self):
+    s, data, isNumerical = self.reader()
+    if isNumerical and s in self.rings and len(data) == self.rings[s].nY:
+      self.rings[s].update(data)
+    else:
+      if s:
+        if len(data) == 0:
+          print(s)
+        else:
+          print(s, *data)
+
+
+  def press(self, event):
+    # Close and quit
+    if event.key == 'q':
+      plt.close(event.canvas.figure)
+      self.reader.closeConnection()
+      exit()
+
+
+
+if __name__ == "__main__":
+  import sys
+  from pipe_reader import Reader
+
+  print(sys.argv)
+  if not len(sys.argv) == 4:
+    print("Usage: <quaternion label> <actual position label> <desired position label>")
+    exit(1)
+
+  plotter = PathPlot(Reader(), *sys.argv[1:])
+  while True:
+    plotter.update()

--- a/plotter.py
+++ b/plotter.py
@@ -32,7 +32,7 @@ def startSocketPlotter(args):
 
 
 def startSerialPlotter(args):
-  import serial_reader
+  import serial_reader_with_crc_binary as serial_reader
   reader = serial_reader.Reader(port=args.serial_port, baudrate=args.baudrate)
   return Plotter(reader=reader, ringLength=args.n_points, labels=args.labels)
 

--- a/plotter.py
+++ b/plotter.py
@@ -26,7 +26,7 @@ args = parser.parse_args()
 
 
 def startSocketPlotter(args):
-  import socket_reader
+  import socket_reader_with_crc as socket_reader
   reader = socket_reader.Reader(host=args.host, port=args.port)
   return Plotter(reader=reader, ringLength=args.n_points, labels=args.labels)
 

--- a/ring.py
+++ b/ring.py
@@ -31,6 +31,9 @@ class Ring(object):
     self.tail = -1
     self.lostTail = np.zeros(self.nY)
 
+  def newest(self):
+    return self.yData[:, self.head]
+
   def looseTail(self):
     self.lostTail = self.yData[:, self.tail].copy()
     self.yData[:, self.tail] = None

--- a/serial_reader_with_crc_binary.py
+++ b/serial_reader_with_crc_binary.py
@@ -1,0 +1,90 @@
+import serial
+import select
+import struct
+import numpy as np
+
+
+# binary format: 
+#   Np D_1 D_2 ... D_n CS \n
+#   - Np    1B plot ID
+#   - D_n   4B data value IEEE745
+#   - CS    1B overall checksum
+# 
+# TODO:
+# - add plot and signal labels
+# - add different encodings (uint, int, etc)
+
+
+def calcCrc(s):
+    crc = 0
+    for c in s:
+        crc ^= c
+    return crc
+
+
+class Reader(object):
+    """ Sets up serial server that data streaming clients can connect to """
+    # Use some random port
+
+    def __init__(self, port="/dev/ttyUSB0", baudrate=57600):
+        print("using serial_reader_with_crc_binary")
+        self.port = port
+        self.baudrate = baudrate
+        self.ser = serial.Serial(port)
+        self.ser.baudrate = baudrate
+
+    def closeConnection(self):
+        self.ser.close()
+
+    def write(self, data):
+        print('Writing: "{:}"'.format(data.strip()))
+        self.ser.write(data.encode("utf-8"))
+
+    def __call__(self, label=None, raw=False, dtype=float):
+        """ label: data group label
+            raw: if true returns the data as it was read (string)
+            dtype: data type that the data is converted to if raw is false """
+        while True:
+            if select.select([self.ser], [], [], 0.02)[0]:
+                rawData = self.ser.readline()
+            else:
+                rawData = b''
+                break;
+
+            if raw:
+                # return whatever was received
+                return rawData
+
+            # convert string into sequence of bytes
+            byteData = bytearray()
+            byteData.extend(rawData)
+            # extract number of data points
+            pointsN = (len(byteData) - 3) / 4
+            if pointsN < 0 or pointsN > int(pointsN):
+                print("points dont match ", pointsN)
+                return rawData, [], False
+            pointsN = int(pointsN)
+            # extract plot ID (label), data points, and checksum
+            fmt = "=B{0}fBx".format(pointsN)
+            labelRead, *dataPoints, crcRead = struct.unpack(fmt, byteData)
+            # calculate checksum
+            crcCalc = calcCrc(rawData[:-2])
+
+            if crcCalc == crcRead:
+                if label is None or label == labelRead:
+                    return str(labelRead), np.array(list(map(dtype, dataPoints))), True
+                else:
+                    print("wrong label")
+            else:
+                print("wrong crc", crcCalc, crcRead)
+            break
+        return rawData, [], False
+
+
+if __name__ == '__main__':
+    reader = Reader()
+
+    while True:
+        data = reader()
+        if data:
+            print(data)

--- a/socket_reader_with_crc.py
+++ b/socket_reader_with_crc.py
@@ -1,0 +1,91 @@
+import socket
+import numpy as np
+import select
+
+
+def calcCrc(s):
+    crc = 0
+    for c in s:
+        crc ^= ord(c)
+    return crc
+
+
+class Reader(object):
+    """ Sets up socket server that data streaming clients can connect to """
+    # Use some random port
+
+    def __init__(self, host, port, dtype=float):
+        self.soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        print("Connecting to {} at {}".format(host, port))
+        self.soc.connect((host, port))
+        print("Connected")
+        self.dtype = dtype
+
+    def closeConnection(self):
+        self.soc.close()
+
+    def write(self, data):
+        self.soc.sendall(data.encode())
+
+    def __call__(self, label=None, raw=False):
+        """ label: data group label
+            raw: if true returns the data as it was read (string)
+            dtype: data type that the data is converted to if raw is false """
+        rawData = ''
+        while True:
+            # Read one byte at a time
+            try:
+                if select.select([self.soc], [], [], 0.5)[0]:
+                    data = self.soc.recv(1)
+                    char = data.decode()
+                else:
+                    break
+            except UnicodeDecodeError:
+                break
+            if not char:
+                # Connection closed or broken
+                print("Connection lost/closed")
+                self.closeConnection()
+                break
+
+            # We expect the data to be terminated with "\r\n"
+            if char == '\r':
+                continue
+            # End of package - return result
+            elif char == '\n':
+
+                if raw:
+                    # return whatever was received
+                    return rawData
+
+                try:
+                    # Interpret the received data
+                    if not rawData:
+                        continue
+                    crc = ord(rawData[-1])
+                    rawData = rawData[:-1]
+                    if crc == calcCrc(rawData):
+                        splittedData = rawData.split(',')
+                        if label is None or label == splittedData[0]:
+                            return splittedData[0], np.array(list(map(self.dtype, splittedData[1:]))), True
+                except ValueError:
+                    return splittedData[0], splittedData[1:], False
+                break
+            else:
+                rawData += char
+        return rawData if raw else rawData, [], False
+
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) == 1:
+        print("Usage: <host address> <host port>")
+        sys.exit()
+
+    host = sys.argv[1]
+    port = int(sys.argv[2])
+    reader = Reader(host, port)
+
+    while True:
+        print(reader())
+        sys.stdout.flush()

--- a/visualizeQuad.py
+++ b/visualizeQuad.py
@@ -1,0 +1,83 @@
+import sys
+import time
+import numpy as np
+import matplotlib
+from matplotlib import pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+
+matplotlib.rcParams['toolbar'] = 'None'
+
+
+def load_src(name, fpath):
+  import os
+  import imp
+  return imp.load_source(name, os.path.join(os.path.dirname(__file__), fpath))
+
+
+mt = load_src('mathTools', 'quaternion/quaternion.py')
+
+
+class QuadPlotter(object):
+  def __init__(self, reader, quaLabel, posLabel=None, axis=False):
+    self.reader = reader
+    self.quaLabel = quaLabel
+    self.posLabel = posLabel
+    self.reader = reader
+    self.fig = plt.figure()
+    self.fig.canvas.mpl_connect('key_press_event', self.press)
+    self.ax = self.fig.add_subplot(1, 1, 1, aspect='equal', projection='3d')
+    self.lines = [self.ax.plot([], [], [], 'r', linewidth=3)[0],
+                  self.ax.plot([], [], [], 'g', linewidth=3)[0],
+                  self.ax.plot([], [], [], 'b', linewidth=3)[0]]
+    self.ax.set_xlabel("x")
+    self.ax.set_ylabel("y")
+    self.ax.set_zlabel("z")
+
+
+    if not axis:
+      self.ax.set_xlim3d(-0.2, 0.2)
+      self.ax.set_ylim3d(-0.2, 0.2)
+      self.ax.set_zlim3d(-0.2, 0.2)
+      self.ax.set_axis_off()
+    else:
+      self.ax.set_xlim3d(-1.0, 1.0)
+      self.ax.set_ylim3d(-1.0, 1.0)
+      self.ax.set_zlim3d(-1.0, 1.0)
+
+
+    self.latestPos = np.zeros(3)
+    self.latestQua = None
+
+    self.timeBetweenPlotUpdates = 0.03
+    self.timeAtLastPlotUpdate = 0
+
+  def press(self, event):
+    if event.key == 'q':
+      plt.close(event.canvas.figure)
+      sys.exit()
+
+  def drawQuad(self, q, pos):
+    lineX = q.rotateVectors(np.array([[-0.3,    0, 0], [0.3,   0,   0]]).T)
+    lineY = q.rotateVectors(np.array([[   0, -0.3, 0], [  0, 0.3,   0]]).T)
+    lineZ = q.rotateVectors(np.array([[   0,    0, 0], [  0,   0, 0.15]]).T)
+
+    self.lines[0].set_xdata(lineX[0, :] + pos[0])
+    self.lines[0].set_ydata(lineX[1, :] + pos[1])
+    self.lines[0].set_3d_properties(lineX[2, :] + pos[2])
+    self.lines[1].set_xdata(lineY[0, :] + pos[0])
+    self.lines[1].set_ydata(lineY[1, :] + pos[1])
+    self.lines[1].set_3d_properties(lineY[2, :] + pos[2])
+    self.lines[2].set_xdata(lineZ[0, :] + pos[0])
+    self.lines[2].set_ydata(lineZ[1, :] + pos[1])
+    self.lines[2].set_3d_properties(lineZ[2, :] + pos[2])
+    plt.pause(0.001)
+
+  def update(self):
+    label, data, isNumerical = self.reader()
+    if isNumerical and label == self.quaLabel:
+      self.latestQua = mt.Quaternion(*data)
+      if time.time() - self.timeAtLastPlotUpdate > self.timeBetweenPlotUpdates:
+        self.drawQuad(self.latestQua, self.latestPos)
+        self.timeAtLastPlotUpdate = time.time()
+    elif isNumerical and self.posLabel is not None and label == self.posLabel:
+      self.latestPos = data


### PR DESCRIPTION
I proceeded to check and merge all of the currently active branches and implemented a binary-based and checksum-ed protocol in the serial reader.

# Format: 
`  Np D_1 D_2 ... D_n CS \n` 
- Np (1B) plot ID
- D_n (4B) data value IEEE745
- CS (1B) overall checksum; same as socket checksum

# Shortcomings
- only floats are supported
- plot labels can only be numbers in the range [1, 255]

# TODO:
- [ ] add plot and trace labels
- [ ] add different encodings (uint, int, etc)